### PR TITLE
Add nmcli to German locale.

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -20,5 +20,11 @@
 		"Signal level": "Signal level",
 		"Scan completed :": "Scan completed :",
 		"Interface doesn't support scanning.": "Interface doesn't support scanning."
-	}
+	},
+	"nmcli": {
+                "SSID": "SSID",
+                "BSSID": "BSSID",
+                "CHAN": "CHAN"
+        }
+
 }


### PR DESCRIPTION
I experienced an error while using this module.
I'm using a Linux system with NetworkManager with the locale `de_DE.UTF-8`.
After digging a bit into the code, I think I found a solution.

This is the stack trace I got:
```
/home/niklas/dev/mapscii/node_modules/node-wifiscanner2/lib/nmcli.js:31
        var cellField = fields[terms[fieldName]];
                                    ^

TypeError: Cannot read property 'SSID' of undefined
    at parseNmcli (/home/niklas/dev/mapscii/node_modules/node-wifiscanner2/lib/nmcli.js:31:37)
    at /home/niklas/dev/mapscii/node_modules/node-wifiscanner2/lib/nmcli.js:48:28
    at ChildProcess.exithandler (child_process.js:204:7)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:854:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:222:5)
```