### PR TITLE
Declare license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Scan surrounding WiFi access points",
   "author": "Bryce Kahle <bryce@particle.io>",
   "main": "./lib/wifiscanner",
+  "license": "BSD 2-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/spark/node-wifiscanner.git"


### PR DESCRIPTION
This dependency is licensed under BSD 2-Clause license. Mark that in the package.json to make it easier to trace software license compliance.